### PR TITLE
Feature prediction interval generalization

### DIFF
--- a/IWXXM/examples/AerodromeWeatherForecast-probability-distribution-p90-95-mean-Example.xml
+++ b/IWXXM/examples/AerodromeWeatherForecast-probability-distribution-p90-95-mean-Example.xml
@@ -175,60 +175,60 @@
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:00:00Z</tsml:time>
                             <iwxxm:mean>1.1 105 1.5</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>1.0 90 1.2</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>1.2 115 1.7</iwxxm:predIntervalConfLevel95Upper>
-                            <iwxxm:predIntervalConfLevel90Lower>0.9 87 1.0</iwxxm:predIntervalConfLevel90Lower>
-                            <iwxxm:predIntervalConfLevel90Upper>1.5 116 1.9</iwxxm:predIntervalConfLevel90Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">1.0 90 1.2</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">1.2 115 1.7</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="lower">0.9 87 1.0</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.99" type="upper">1.5 116 1.9</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:10:00Z</tsml:time>
                             <iwxxm:mean>2.3 110 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>2.2 105 3.5</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>2.5 113 4.5</iwxxm:predIntervalConfLevel95Upper>
-                            <iwxxm:predIntervalConfLevel90Lower>2.1 100 3.2</iwxxm:predIntervalConfLevel90Lower>
-                            <iwxxm:predIntervalConfLevel90Upper>2.6 117 4.8</iwxxm:predIntervalConfLevel90Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">2.2 105 3.5</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">2.5 113 4.5</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="lower">2.1 100 3.2</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="upper">2.6 117 4.8</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:20:00Z</tsml:time>
                             <iwxxm:mean>3.1 112 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>3.0 95.1 4.0</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>3.2 115 4.7</iwxxm:predIntervalConfLevel95Upper>
-                            <iwxxm:predIntervalConfLevel90Lower>2.8 93.1 3.9</iwxxm:predIntervalConfLevel90Lower>
-                            <iwxxm:predIntervalConfLevel90Upper>3.3 118 4.2</iwxxm:predIntervalConfLevel90Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">3.0 95.1 4.0</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">3.2 115 4.7</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="lower">2.8 93.1 3.9</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="upper">3.3 118 4.2</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:30:00Z</tsml:time>
                             <iwxxm:mean>1.6 113 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>1.5 94.0 2.0</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>1.7 117 2.7</iwxxm:predIntervalConfLevel95Upper>
-                            <iwxxm:predIntervalConfLevel90Lower>1.3 93.5 1.9</iwxxm:predIntervalConfLevel90Lower>
-                            <iwxxm:predIntervalConfLevel90Upper>2.1 118 2.8</iwxxm:predIntervalConfLevel90Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">1.5 94.0 2.0</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">1.7 117 2.7</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="lower">1.3 93.5 1.9</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="upper">2.1 118 2.8</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:40:00Z</tsml:time>
                             <iwxxm:mean>1.7 112 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>1.5 94.0 2.5</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>1.8 114 3.1</iwxxm:predIntervalConfLevel95Upper>
-                            <iwxxm:predIntervalConfLevel90Lower>1.4 92.0 2.3</iwxxm:predIntervalConfLevel90Lower>
-                            <iwxxm:predIntervalConfLevel90Upper>3.2 115 3.2</iwxxm:predIntervalConfLevel90Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">1.5 94.0 2.5</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">1.8 114 3.1</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="lower">1.4 92.0 2.3</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="upper">3.2 115 3.2</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:50:00Z</tsml:time>
                             <iwxxm:mean>1.6 111 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>1.5 94.0 2.3</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>1.7 116 3.0</iwxxm:predIntervalConfLevel95Upper>
-                            <iwxxm:predIntervalConfLevel90Lower>1.4 92.0 2.1</iwxxm:predIntervalConfLevel90Lower>
-                            <iwxxm:predIntervalConfLevel90Upper>2.5 118 3.2</iwxxm:predIntervalConfLevel90Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">1.5 94.0 2.3</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">1.7 116 3.0</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="lower">1.4 92.0 2.1</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.90" type="upper">2.5 118 3.2</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                    

--- a/IWXXM/examples/AerodromeWeatherForecast-probability-distribution-p95-mean-Example.xml
+++ b/IWXXM/examples/AerodromeWeatherForecast-probability-distribution-p95-mean-Example.xml
@@ -176,48 +176,48 @@
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:00:00Z</tsml:time>
                             <iwxxm:mean>1.1 105 1.5</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>1.0 90 1.2</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>1.2 115 1.7</iwxxm:predIntervalConfLevel95Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">1.0 90 1.2</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">1.2 115 1.7</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:10:00Z</tsml:time>
                             <iwxxm:mean>2.3 110 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>2.2 105 3.5</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>2.5 113 4.5</iwxxm:predIntervalConfLevel95Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">2.2 105 3.5</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">2.5 113 4.5</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:20:00Z</tsml:time>
                             <iwxxm:mean>3.1 112 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>3.0 95.1 4.0</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>3.2 115 4.7</iwxxm:predIntervalConfLevel95Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">3.0 95.1 4.0</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">3.2 115 4.7</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:30:00Z</tsml:time>
                             <iwxxm:mean>1.6 113 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>1.5 94.0 2.0</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>1.7 117 2.7</iwxxm:predIntervalConfLevel95Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">1.5 94.0 2.0</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">1.7 117 2.7</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:40:00Z</tsml:time>
                             <iwxxm:mean>1.7 112 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>1.5 94.0 2.5</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>1.8 114 3.1</iwxxm:predIntervalConfLevel95Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">1.5 94.0 2.5</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">1.8 114 3.1</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                     <tsml:point>
                         <iwxxm:DistributionRecordTVP>
                             <tsml:time>2001-01-31T00:50:00Z</tsml:time>
                             <iwxxm:mean>1.6 111 4.1</iwxxm:mean>
-                            <iwxxm:predIntervalConfLevel95Lower>1.5 94.0 2.3</iwxxm:predIntervalConfLevel95Lower>
-                            <iwxxm:predIntervalConfLevel95Upper>1.7 116 3.0</iwxxm:predIntervalConfLevel95Upper>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="lower">1.5 94.0 2.3</iwxxm:predictionIntervalBoundary>
+                            <iwxxm:predictionIntervalBoundary level="0.95" type="upper">1.7 116 3.0</iwxxm:predictionIntervalBoundary>
                         </iwxxm:DistributionRecordTVP>
                     </tsml:point>
                    

--- a/IWXXM/swe-ext.xsd
+++ b/IWXXM/swe-ext.xsd
@@ -163,12 +163,6 @@
         <attributeGroup ref="gml:OwnershipAttributeGroup" />
     </complexType>
     
-    <group name="DesciptiveStatisticsMeasures">
-        <sequence>
-            
-        </sequence>    
-    </group>
-    
     <element name="DescriptiveStatistics" type="iwxxm:DescriptiveStatisticsType">
         <annotation>
             <documentation>
@@ -186,31 +180,25 @@
             <element name="count" type="integer" minOccurs="0"/>
             <element name="minimum" type="anySimpleType" minOccurs="0"/>
             <element name="maximum" type="anySimpleType" minOccurs="0"/>
-            <element name="predIntervalConfLevel95" minOccurs="0">
+            <element name="predictionInterval" minOccurs="0" maxOccurs="unbounded">
                 <annotation>
-                    <documentation>Prediction interval at confidence level 95%</documentation>
+                    <documentation>Prediction interval (lower, upper) at the given confidence 
+                        level (0.0 - 1.0) as a space-separated pair of doubles</documentation>
                 </annotation>
-                <simpleType>
-                    <restriction>
-                        <simpleType>
-                            <list itemType="double"/>
-                        </simpleType>
-                        <length value="2"/>
-                    </restriction>
-                </simpleType>
-            </element>
-            <element name="predIntervalConfLevel90" minOccurs="0">
-                <annotation>
-                    <documentation>Prediction interval at confidence level 90%</documentation>
-                </annotation>
-                <simpleType>
-                    <restriction>
-                        <simpleType>
-                            <list itemType="double"/>
-                        </simpleType>
-                        <length value="2"/>
-                    </restriction>
-                </simpleType>
+                <complexType>
+                    <simpleContent>
+                        <extension base="iwxxm:PairOFDouble">
+                            <attribute name="level" use="required">
+                                <simpleType>
+                                    <restriction base="double">
+                                        <minInclusive value="0"/>
+                                        <maxInclusive value="1"/>
+                                    </restriction>
+                                </simpleType>
+                            </attribute>
+                        </extension>
+                    </simpleContent>
+                </complexType>
             </element>
         </sequence>
     </complexType>
@@ -222,4 +210,12 @@
         <attributeGroup ref="gml:OwnershipAttributeGroup" />
     </complexType>
    
+    <xs:simpleType name="PairOFDouble">
+        <restriction>
+            <simpleType>
+                <list itemType="double"/>
+            </simpleType>
+            <length value="2"/>
+        </restriction>
+    </xs:simpleType>
 </schema>

--- a/IWXXM/swe-ext.xsd
+++ b/IWXXM/swe-ext.xsd
@@ -187,7 +187,7 @@
                 </annotation>
                 <complexType>
                     <simpleContent>
-                        <extension base="iwxxm:PairOFDouble">
+                        <extension base="iwxxm:PairOFAnySimpleType">
                             <attribute name="level" use="required">
                                 <simpleType>
                                     <restriction base="double">
@@ -210,10 +210,10 @@
         <attributeGroup ref="gml:OwnershipAttributeGroup" />
     </complexType>
    
-    <xs:simpleType name="PairOFDouble">
+    <xs:simpleType name="PairOFAnySimpleType">
         <restriction>
             <simpleType>
-                <list itemType="double"/>
+                <list itemType="xs:anySimpleType"/>
             </simpleType>
             <length value="2"/>
         </restriction>

--- a/IWXXM/tsml-ext.xsd
+++ b/IWXXM/tsml-ext.xsd
@@ -149,7 +149,7 @@
                         </annotation>
                         <complexType>
                             <simpleContent>
-                                <extension base="iwxxm:ListOFDouble">
+                                <extension base="iwxxm:ListOFAnySimpleType">
                                     <attribute name="level" use="required">
                                         <simpleType>
                                             <restriction base="double">

--- a/IWXXM/tsml-ext.xsd
+++ b/IWXXM/tsml-ext.xsd
@@ -13,7 +13,6 @@
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
     <import namespace="http://www.opengis.net/timeseriesml/1.3/iwxxm" schemaLocation="../externalSchema/schemas.opengis.net/tsml-iwxxm/1.3/timeseriesML.xsd"></import>
     
-    <!-- Added FieldSpecificPointMetadata to introduce possibility for providing point metadata for each field in a record type TVP / Ilkka Rinne 2024-04-16 -->
 	<xs:element name="FieldSpecificPointMetadata" type="iwxxm:FieldSpecificPointMetadataType" substitutionGroup="tsml:PointMetadata">
 		<xs:annotation>
 			<xs:documentation>Metadata relating to individual data points (can be set to a default for the whole timeseries).</xs:documentation>
@@ -67,10 +66,13 @@
         <xs:complexContent>
             <xs:extension base="tsml:TimeValuePairType">
                 <xs:sequence>
-                    <xs:element name="value" type="xs:anySimpleType" minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="value" minOccurs="0" maxOccurs="1">
                         <xs:annotation>
                             <xs:documentation>The structured value value for this data point</xs:documentation>
                         </xs:annotation>
+                        <xs:simpleType>
+                            <xs:list itemType="xs:anySimpleType"/>
+                        </xs:simpleType>
                     </xs:element>
                 </xs:sequence>
             </xs:extension>
@@ -125,77 +127,48 @@
         <xs:complexContent>
             <xs:extension base="tsml:TimeValuePairType">
                 <xs:sequence>
-                    <element name="mean" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:list itemType="xs:double"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="median" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:list itemType="xs:anySimpleType"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="mode" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:list itemType="xs:anySimpleType"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="variance" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:list itemType="xs:double"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="standardDeviation" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:list itemType="xs:double"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="count" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:list itemType="xs:integer"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="minimum" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:list itemType="xs:anySimpleType"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="maximum" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:list itemType="xs:anySimpleType"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="predIntervalConfLevel95Lower" minOccurs="0">
+                    <element name="mean" type="iwxxm:ListOFDouble" minOccurs="0"/>
+                    
+                    <element name="median" type="iwxxm:ListOFAnySimpleType" minOccurs="0"/>
+                    
+                    <element name="mode" type="iwxxm:ListOFAnySimpleType" minOccurs="0"/>
+                     
+                    <element name="variance" type="iwxxm:ListOFDouble" minOccurs="0"/>
+                    
+                    <element name="standardDeviation" type="iwxxm:ListOFDouble" minOccurs="0"/>
+                     
+                    <element name="count" type="iwxxm:ListOFInteger" minOccurs="0"/>
+                     
+                    <element name="minimum"  type="iwxxm:ListOFAnySimpleType" minOccurs="0"/>
+                     
+                    <element name="maximum" type="iwxxm:ListOFAnySimpleType" minOccurs="0"/>
+                     
+                    <element name="predictionIntervalBoundary" minOccurs="0" maxOccurs="unbounded">
                         <annotation>
-                            <documentation>Prediction interval (PI) for conficence level 95%</documentation>
+                            <documentation>Prediction interval (PI) for confidence level between 0.0 and 1.0</documentation>
                         </annotation>
-                        <xs:simpleType>
-                            <xs:list itemType="xs:double"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="predIntervalConfLevel95Upper" minOccurs="0">
-                        <annotation>
-                            <documentation>Prediction interval (PI) upper boundary for conficence level 95%</documentation>
-                        </annotation>
-                        <xs:simpleType>
-                            <xs:list itemType="xs:double"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="predIntervalConfLevel90Lower" minOccurs="0">
-                        <annotation>
-                            <documentation>Prediction interval (PI) lower boundary for conficence level 90%</documentation>
-                        </annotation>
-                        <xs:simpleType>
-                            <xs:list itemType="xs:double"/>
-                        </xs:simpleType>
-                    </element>
-                    <element name="predIntervalConfLevel90Upper" minOccurs="0">
-                        <annotation>
-                            <documentation>Prediction interval (PI) upper boundary for conficence level 90%</documentation>
-                        </annotation>
-                        <xs:simpleType>
-                            <xs:list itemType="xs:double"/>
-                        </xs:simpleType>
+                        <complexType>
+                            <simpleContent>
+                                <extension base="iwxxm:ListOFDouble">
+                                    <attribute name="level" use="required">
+                                        <simpleType>
+                                            <restriction base="double">
+                                                <minInclusive value="0"/>
+                                                <maxInclusive value="1"/>
+                                            </restriction>
+                                        </simpleType>
+                                    </attribute>
+                                    <attribute name="type" use="required">
+                                        <simpleType>
+                                            <restriction base="string">
+                                                <enumeration value="upper"/>
+                                                <enumeration value="lower"/>
+                                            </restriction>
+                                        </simpleType>
+                                    </attribute>
+                                </extension>
+                            </simpleContent>
+                        </complexType>
                     </element>
                 </xs:sequence>
             </xs:extension>
@@ -209,4 +182,15 @@
         <xs:attributeGroup ref="gml:OwnershipAttributeGroup"/>
     </xs:complexType>
     
+    <xs:simpleType name="ListOFAnySimpleType">
+        <list itemType="xs:anySimpleType"/>  
+    </xs:simpleType>
+    
+    <xs:simpleType name="ListOFDouble">
+        <list itemType="xs:double"/>  
+    </xs:simpleType>
+    
+    <xs:simpleType name="ListOFInteger">
+        <list itemType="xs:integer"/>  
+    </xs:simpleType>
 </schema>

--- a/IWXXM/tsml-ext.xsd
+++ b/IWXXM/tsml-ext.xsd
@@ -13,26 +13,26 @@
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"></import>
     <import namespace="http://www.opengis.net/timeseriesml/1.3/iwxxm" schemaLocation="../externalSchema/schemas.opengis.net/tsml-iwxxm/1.3/timeseriesML.xsd"></import>
     
-	<xs:element name="FieldSpecificPointMetadata" type="iwxxm:FieldSpecificPointMetadataType" substitutionGroup="tsml:PointMetadata">
-		<xs:annotation>
-			<xs:documentation>Metadata relating to individual data points (can be set to a default for the whole timeseries).</xs:documentation>
-		</xs:annotation>
-	</xs:element>
-	<xs:complexType name="FieldSpecificPointMetadataType">
-		<xs:complexContent>
-			<xs:extension base="tsml:PointMetadataType">
-				<xs:attribute name="field" type="xs:NCName" use="required" />
-				<xs:attribute name="position" type="xs:int" use="optional" />
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<xs:complexType name="FieldSpecificPointMetadataPropertyType">
-		<xs:sequence>
-			<xs:element ref="iwxxm:FieldSpecificPointMetadata"/>
-		</xs:sequence>
-		<xs:attributeGroup ref="gml:OwnershipAttributeGroup"/>
-	</xs:complexType>
-
+    <xs:element name="FieldSpecificPointMetadata" type="iwxxm:FieldSpecificPointMetadataType" substitutionGroup="tsml:PointMetadata">
+        <xs:annotation>
+            <xs:documentation>Metadata relating to individual data points (can be set to a default for the whole timeseries).</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:complexType name="FieldSpecificPointMetadataType">
+        <xs:complexContent>
+            <xs:extension base="tsml:PointMetadataType">
+                <xs:attribute name="field" type="xs:NCName" use="required" />
+                <xs:attribute name="position" type="xs:int" use="optional" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="FieldSpecificPointMetadataPropertyType">
+        <xs:sequence>
+            <xs:element ref="iwxxm:FieldSpecificPointMetadata"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="gml:OwnershipAttributeGroup"/>
+    </xs:complexType>
+    
     <element name="LinkedTimeseriesTVP" type="iwxxm:LinkedTimeseriesTVPType" substitutionGroup="tsml:TimeseriesTVP">
         <annotation>
             <documentation>An extension to TSML:TimeseriesTVP with optional references to the previous and the next part of the timeseries.
@@ -132,17 +132,17 @@
                     <element name="median" type="iwxxm:ListOFAnySimpleType" minOccurs="0"/>
                     
                     <element name="mode" type="iwxxm:ListOFAnySimpleType" minOccurs="0"/>
-                     
+                    
                     <element name="variance" type="iwxxm:ListOFDouble" minOccurs="0"/>
                     
                     <element name="standardDeviation" type="iwxxm:ListOFDouble" minOccurs="0"/>
-                     
+                    
                     <element name="count" type="iwxxm:ListOFInteger" minOccurs="0"/>
-                     
+                    
                     <element name="minimum"  type="iwxxm:ListOFAnySimpleType" minOccurs="0"/>
-                     
+                    
                     <element name="maximum" type="iwxxm:ListOFAnySimpleType" minOccurs="0"/>
-                     
+                    
                     <element name="predictionIntervalBoundary" minOccurs="0" maxOccurs="unbounded">
                         <annotation>
                             <documentation>Prediction interval (PI) for confidence level between 0.0 and 1.0</documentation>


### PR DESCRIPTION
* prediction interval now defined in a more generic way, not limited to 90% & 95% levels for DistributionRecordTVP/ and QuantityProbabilityDistribution/descriptiveStatistics
Also small schema fix for the value of the RecordTVP: now consistent with the other record-like TVP types: a 0..1 multiplicity list of anyType